### PR TITLE
Manage pages

### DIFF
--- a/react-app/src/components/ClientGrid/index.tsx
+++ b/react-app/src/components/ClientGrid/index.tsx
@@ -4,6 +4,7 @@ import RemoveClientModal from '../RemoveClientModal/RemoveClientModal';
 import { DataGrid, GridColDef, GridRowId, gridClasses } from '@mui/x-data-grid';
 import { alpha, styled } from '@mui/material/styles';
 import CreateClientModal from '../CreateClientModal/createClientModal';
+import ManageClientModal from '../ManageClientModal/manageClientModal'
 
 import './ClientGrid.css';
 
@@ -124,10 +125,28 @@ const createNewRow = (prevRows: {
 export default function ClientGrid() {
     const [selectionModel, setSelectionModel] = React.useState<GridRowId[]>([]);
     const [rows, setRows] = React.useState(() => clientRows);
+    const [selectedClient, setSelectedClient] = React.useState([{
+        clientName: '',
+        organization: '',
+        email: '',
+        status: ''
+    }]);
+    const [manageDisabled, setManageDisabled] = React.useState(true)
 
     const deleteClients = () => {
         setRows((rows) => rows.filter((r) => !selectionModel.includes(r.id)));
     };
+
+    function checkDisableManage() {
+        if (selectedClient == null
+            || selectedClient.length == 0
+            || selectedClient.length > 1
+            || selectedClient[0].clientName == '') {
+            setManageDisabled(true)
+        } else {
+            setManageDisabled(false)
+        }
+    }
 
 
     const getCreateClientInfo = (
@@ -140,6 +159,10 @@ export default function ClientGrid() {
         setRows((prevRows) => [...prevRows, createNewRow(prevRows, clientName, organization, email, status)]);
 
     }
+
+    React.useEffect(() => {
+        checkDisableManage();
+    })
 
     return (
         <div className="main_content">
@@ -172,7 +195,10 @@ export default function ClientGrid() {
                     checkboxSelection
                     experimentalFeatures={{ newEditingApi: true }}
                     selectionModel={selectionModel}
-                    onSelectionModelChange={setSelectionModel}
+                    onSelectionModelChange={(newSelectionModel) => {
+                        setSelectionModel(newSelectionModel);
+                        setSelectedClient(rows.filter((r: any) => newSelectionModel.includes(r.id)));
+                    }}
                     sx = {{
                         border: 2
                     }}
@@ -202,13 +228,7 @@ export default function ClientGrid() {
                 </div>
 
                 <div className="bottom_buttons_group">
-                    <Button variant="contained" onClick={() => {
-                        // TODO: Handle click here
-                        console.log('manage client clicked')
-                    }}
-                    >
-                        Manage Selected Client
-                    </Button>
+                    <ManageClientModal rows={rows} selectionModel={selectionModel} manageDisabled={manageDisabled} />
                     <RemoveClientModal deleteClients={deleteClients}/>
                 </div>
             </div>

--- a/react-app/src/components/ManageClientModal/manageClientModal.tsx
+++ b/react-app/src/components/ManageClientModal/manageClientModal.tsx
@@ -4,7 +4,6 @@ import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import Modal from '@mui/material/Modal';
 
-
 const style = {
     position: 'absolute' as 'absolute',
     top: '50%',
@@ -17,36 +16,35 @@ const style = {
     p: 4,
 };
 
-export default function ManageTeamModal(props: {
+export default function ManageClientModal(props: {
     rows: {
-        teamNumber: string,
-        section: string,
-        project: string,
-        client: string,
-        professor: string
-    }[]; selectionModel: string | any[]; 
+        clientName: string,
+        organization: string,
+        email: string,
+        status: string
+    }[]; selectionModel: string | any[];
     manageDisabled: boolean}) {
 
     const [open, setOpen] = React.useState(false);
-    const [selectedTeam, setSelectedTeam] = React.useState([{
-        teamNumber: '',
-        section: '',
-        project: '',
-        client: '',
-        professor: ''
-    }])
+    const [selectedClient, setSelectedClient] = React.useState([{
+        clientName: '',
+        organization: '',
+        email: '',
+        status: ''
+    }]);
 
     const handleOpen = () => {
-        setSelectedTeam(props.rows.filter((r: any) => props.selectionModel.includes(r.id)))
+        setSelectedClient(props.rows.filter((r: any) => props.selectionModel.includes(r.id)))
         setOpen(true);
     }
     const handleClose = () => setOpen(false);
+
 
     return (
         <div>
             <Button variant="contained" onClick={handleOpen} disabled={props.manageDisabled}
             >
-                Manage Selected Team
+                Manage Selected Client
             </Button>
             <Modal
                 open={open}
@@ -56,14 +54,15 @@ export default function ManageTeamModal(props: {
             >
                 <Box sx={style}>
                     <Typography id="modal-modal-title" variant="h6" component="h2">
-                        Team {selectedTeam[0].teamNumber}
-                    </Typography>
-                    <Typography component={'div'} id="modal-modal-description" sx={{ mt: 2 }}>
-                        {/* Team info will go here */}                        
+                        Client - {selectedClient[0].clientName}
                     </Typography>
 
+                    <Typography component={'div'} id="modal-modal-description" sx={{ mt: 2 }}>
+                        {/* client info here*/}
+                    </Typography>
                 </Box>
             </Modal>
         </div>
     );
 }
+

--- a/react-app/src/components/ManageProjectModal/manageProjectModal.tsx
+++ b/react-app/src/components/ManageProjectModal/manageProjectModal.tsx
@@ -4,7 +4,6 @@ import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import Modal from '@mui/material/Modal';
 
-
 const style = {
     position: 'absolute' as 'absolute',
     top: '50%',
@@ -17,36 +16,36 @@ const style = {
     p: 4,
 };
 
-export default function ManageTeamModal(props: {
+export default function ManageProjectModal(props: {
     rows: {
-        teamNumber: string,
-        section: string,
-        project: string,
-        client: string,
-        professor: string
-    }[]; selectionModel: string | any[]; 
-    manageDisabled: boolean}) {
+        clientName: '',
+        organization: '',
+        email: '',
+        status: ''
+    }[]; selectionModel: string | any[];
+    manageDisabled: boolean
+}) {
 
     const [open, setOpen] = React.useState(false);
-    const [selectedTeam, setSelectedTeam] = React.useState([{
-        teamNumber: '',
-        section: '',
-        project: '',
-        client: '',
-        professor: ''
-    }])
+    const [selectedClient, setSelectedClient] = React.useState([{
+        clientName: '',
+        organization: '',
+        email: '',
+        status: ''
+    }]);
 
     const handleOpen = () => {
-        setSelectedTeam(props.rows.filter((r: any) => props.selectionModel.includes(r.id)))
+        setSelectedClient(props.rows.filter((r: any) => props.selectionModel.includes(r.id)))
         setOpen(true);
     }
     const handleClose = () => setOpen(false);
+
 
     return (
         <div>
             <Button variant="contained" onClick={handleOpen} disabled={props.manageDisabled}
             >
-                Manage Selected Team
+                Manage Selected Client
             </Button>
             <Modal
                 open={open}
@@ -56,14 +55,15 @@ export default function ManageTeamModal(props: {
             >
                 <Box sx={style}>
                     <Typography id="modal-modal-title" variant="h6" component="h2">
-                        Team {selectedTeam[0].teamNumber}
-                    </Typography>
-                    <Typography component={'div'} id="modal-modal-description" sx={{ mt: 2 }}>
-                        {/* Team info will go here */}                        
+                        Team {selectedClient[0].clientName}
                     </Typography>
 
+                    <Typography component={'div'} id="modal-modal-description" sx={{ mt: 2 }}>
+                        {/* client info here*/}
+                    </Typography>
                 </Box>
             </Modal>
         </div>
     );
 }
+

--- a/react-app/src/components/ManageProjectModal/manageProjectModal.tsx
+++ b/react-app/src/components/ManageProjectModal/manageProjectModal.tsx
@@ -18,24 +18,26 @@ const style = {
 
 export default function ManageProjectModal(props: {
     rows: {
-        clientName: '',
-        organization: '',
-        email: '',
-        status: ''
+        teamAssigned: string,
+        section: string,
+        organization: string,
+        client: string,
+        status: string
     }[]; selectionModel: string | any[];
     manageDisabled: boolean
 }) {
 
     const [open, setOpen] = React.useState(false);
-    const [selectedClient, setSelectedClient] = React.useState([{
-        clientName: '',
+    const [selectedProject, setSelectedProject] = React.useState([{
+        teamAssigned: '',
+        section: '',
         organization: '',
-        email: '',
+        client: '',
         status: ''
     }]);
 
     const handleOpen = () => {
-        setSelectedClient(props.rows.filter((r: any) => props.selectionModel.includes(r.id)))
+        setSelectedProject(props.rows.filter((r: any) => props.selectionModel.includes(r.id)))
         setOpen(true);
     }
     const handleClose = () => setOpen(false);
@@ -45,7 +47,7 @@ export default function ManageProjectModal(props: {
         <div>
             <Button variant="contained" onClick={handleOpen} disabled={props.manageDisabled}
             >
-                Manage Selected Client
+                Manage Selected Project
             </Button>
             <Modal
                 open={open}
@@ -55,11 +57,11 @@ export default function ManageProjectModal(props: {
             >
                 <Box sx={style}>
                     <Typography id="modal-modal-title" variant="h6" component="h2">
-                        Team {selectedClient[0].clientName}
+                        Project from {selectedProject[0].client}
                     </Typography>
 
                     <Typography component={'div'} id="modal-modal-description" sx={{ mt: 2 }}>
-                        {/* client info here*/}
+                        {/* project info here*/}
                     </Typography>
                 </Box>
             </Modal>

--- a/react-app/src/components/ManageTeamModal/manageTeamModal.tsx
+++ b/react-app/src/components/ManageTeamModal/manageTeamModal.tsx
@@ -30,7 +30,8 @@ export default function ManageTeamModal(props: {
         project: string,
         client: string,
         professor: string
-    }[]; selectionModel: string | any[]; }) {
+    }[]; selectionModel: string | any[]; 
+    manageDisabled: boolean}) {
     const [open, setOpen] = React.useState(false);
 
     const [teamNumber, setTeamNumber] = React.useState('');
@@ -76,7 +77,7 @@ export default function ManageTeamModal(props: {
 
     return (
         <div>
-            <Button variant="contained" onClick={handleOpen}
+            <Button variant="contained" onClick={handleOpen} disabled={props.manageDisabled}
             >
                 Manage Selected Team
             </Button>

--- a/react-app/src/components/ManageTeamModal/manageTeamModal.tsx
+++ b/react-app/src/components/ManageTeamModal/manageTeamModal.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import FormControl from '@mui/material/FormControl';
+import Input from '@mui/material/Input';
+import InputLabel from '@mui/material/InputLabel';
+import TextField from '@mui/material/TextField'
+import Modal from '@mui/material/Modal';
+
+
+const style = {
+    position: 'absolute' as 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: 500,
+    bgcolor: 'background.paper',
+    border: '2px solid #000',
+    boxShadow: 24,
+    p: 4,
+};
+// getManageTeamInfo will go in {}
+export default function ManageTeamModal({  }: any) {
+    const [open, setOpen] = React.useState(false);
+
+    const [teamNumber, setTeamNumber] = React.useState('');
+    const [section, setSection] = React.useState('');
+    const [projName, setProjName] = React.useState('');
+    const [clientName, setClientName] = React.useState('');
+    const [profName, setProfName] = React.useState('');
+
+    const handleOpen = () => setOpen(true);
+    const handleClose = () => setOpen(false);
+
+    function handleTeamNumberChange(event: React.ChangeEvent<HTMLInputElement>) {
+        setTeamNumber(event.target.value);
+    }
+
+    function handleSectionChange(event: React.ChangeEvent<HTMLInputElement>) {
+        setSection(event.target.value);
+    }
+
+    function handleProjNameChange(event: React.ChangeEvent<HTMLInputElement>) {
+        setProjName(event.target.value);
+    }
+
+    function handleClientNameChange(event: React.ChangeEvent<HTMLInputElement>) {
+        setClientName(event.target.value);
+    }
+
+    function handleProfNameChange(event: React.ChangeEvent<HTMLInputElement>) {
+        setProfName(event.target.value);
+    }
+
+    return (
+        <div>
+            <Button variant="contained" onClick={handleOpen}>
+                Manage Selected Team
+            </Button>
+            <Modal
+                open={open}
+                onClose={handleClose}
+                aria-labelledby="modal-modal-title"
+                aria-describedby="modal-modal-description"
+            >
+                <Box sx={style}>
+                    <Typography id="modal-modal-title" variant="h6" component="h2">
+                        Team ___
+                    </Typography>
+                    <Typography component={'div'} id="modal-modal-description" sx={{ mt: 2 }}>
+                        {/* Team info will go here */}
+                    </Typography>
+
+                </Box>
+            </Modal>
+        </div>
+    );
+}

--- a/react-app/src/components/ManageTeamModal/manageTeamModal.tsx
+++ b/react-app/src/components/ManageTeamModal/manageTeamModal.tsx
@@ -7,6 +7,8 @@ import Input from '@mui/material/Input';
 import InputLabel from '@mui/material/InputLabel';
 import TextField from '@mui/material/TextField'
 import Modal from '@mui/material/Modal';
+import { DataGrid, GridColDef, GridRowId, gridClasses } from '@mui/x-data-grid';
+
 
 
 const style = {
@@ -21,7 +23,14 @@ const style = {
     p: 4,
 };
 // getManageTeamInfo will go in {}
-export default function ManageTeamModal({  }: any) {
+export default function ManageTeamModal(props: {
+    rows: {
+        teamNumber: string,
+        section: string,
+        project: string,
+        client: string,
+        professor: string
+    }[]; selectionModel: string | any[]; }) {
     const [open, setOpen] = React.useState(false);
 
     const [teamNumber, setTeamNumber] = React.useState('');
@@ -29,8 +38,18 @@ export default function ManageTeamModal({  }: any) {
     const [projName, setProjName] = React.useState('');
     const [clientName, setClientName] = React.useState('');
     const [profName, setProfName] = React.useState('');
+    const [selectedTeam, setSelectedTeam] = React.useState([{
+        teamNumber: '',
+        section: '',
+        project: '',
+        client: '',
+        professor: ''
+    }])
 
-    const handleOpen = () => setOpen(true);
+    const handleOpen = () => {
+        setSelectedTeam(props.rows.filter((r: any) => props.selectionModel.includes(r.id)))
+        setOpen(true);
+    }
     const handleClose = () => setOpen(false);
 
     function handleTeamNumberChange(event: React.ChangeEvent<HTMLInputElement>) {
@@ -51,11 +70,14 @@ export default function ManageTeamModal({  }: any) {
 
     function handleProfNameChange(event: React.ChangeEvent<HTMLInputElement>) {
         setProfName(event.target.value);
-    }
+    } 
+
+
 
     return (
         <div>
-            <Button variant="contained" onClick={handleOpen}>
+            <Button variant="contained" onClick={handleOpen}
+            >
                 Manage Selected Team
             </Button>
             <Modal
@@ -66,10 +88,10 @@ export default function ManageTeamModal({  }: any) {
             >
                 <Box sx={style}>
                     <Typography id="modal-modal-title" variant="h6" component="h2">
-                        Team ___
+                        Team {selectedTeam[0].teamNumber}
                     </Typography>
                     <Typography component={'div'} id="modal-modal-description" sx={{ mt: 2 }}>
-                        {/* Team info will go here */}
+                        {/* Team info will go here */}                        
                     </Typography>
 
                 </Box>

--- a/react-app/src/components/ProjectsGrid/index.tsx
+++ b/react-app/src/components/ProjectsGrid/index.tsx
@@ -4,6 +4,7 @@ import RemoveProjectsModal from '../RemoveProjectsModal/RemoveProjectsModal';
 import { DataGrid, GridColDef, GridRowId, gridClasses } from '@mui/x-data-grid';
 import { alpha, styled } from '@mui/material/styles';
 import CreateProjectModal from '../CreateProjectModal/createProjectModal';
+import ManageProjectModal from '../ManageProjectModal/manageProjectModal';
 
 import './ProjectsGrid.css';
 
@@ -97,26 +98,26 @@ const projectsColumns: GridColDef[] = [
 ];
 
 const projectsRows = [
-    { id: 1, client: 'Tony Stark', section: 'JDA', organization: 'Mock Org name', teamAssigned: 2100, status: 'Active'},
-    { id: 2, client: 'Carol Denvers', section: 'JDA', organization: 'Mock Org name', teamAssigned: 2101, status: 'Active' },
-    { id: 3, client: 'Stephen Strange', section: 'JDA', organization: 'Mock Org name', teamAssigned: 2102, status: 'Active' },
-    { id: 4, client: 'Peter Quill', section: 'JDA', organization: 'Mock Org name', teamAssigned: 2103, status: 'Active' },
-    { id: 5, client: 'Steve Rogers', section: 'JDA', organization: 'Mock Org name', teamAssigned: 2104, status: 'Active' },
-    { id: 6, client: 'Bucky Barnes', section: 'JDA', organization: 'Mock Org name', teamAssigned: 2105, status: 'Active' },
-    { id: 7, client: 'Bruce Banner', section: 'JIA', organization: 'Mock Org name', teamAssigned: 0, status: 'Unassigned' },
-    { id: 8, client: 'Eddie Brock', section: 'JIA', organization: 'Mock Org name', teamAssigned: 0, status: 'Unassigned' },
-    { id: 9, client: 'Pepper Potts', section: 'JIA', organization: 'Mock Org name', teamAssigned: 0, status: 'Unassigned' },
-    { id: 10, client: 'Nick Fury', section: 'JDF', organization: 'Mock Org name', teamAssigned: 0, status: 'Completed' },
-    { id: 11, client: 'Peter Parker', section: 'JDF', organization: 'Mock Org name', teamAssigned: 0, status: 'Completed' }
+    { id: 1, client: 'Tony Stark', section: 'JDA', organization: 'Mock Org name', teamAssigned: '2100', status: 'Active'},
+    { id: 2, client: 'Carol Denvers', section: 'JDA', organization: 'Mock Org name', teamAssigned: '2101', status: 'Active' },
+    { id: 3, client: 'Stephen Strange', section: 'JDA', organization: 'Mock Org name', teamAssigned: '2102', status: 'Active' },
+    { id: 4, client: 'Peter Quill', section: 'JDA', organization: 'Mock Org name', teamAssigned: '2103', status: 'Active' },
+    { id: 5, client: 'Steve Rogers', section: 'JDA', organization: 'Mock Org name', teamAssigned: '2104', status: 'Active' },
+    { id: 6, client: 'Bucky Barnes', section: 'JDA', organization: 'Mock Org name', teamAssigned: '2105', status: 'Active' },
+    { id: 7, client: 'Bruce Banner', section: 'JIA', organization: 'Mock Org name', teamAssigned: '0', status: 'Unassigned' },
+    { id: 8, client: 'Eddie Brock', section: 'JIA', organization: 'Mock Org name', teamAssigned: '0', status: 'Unassigned' },
+    { id: 9, client: 'Pepper Potts', section: 'JIA', organization: 'Mock Org name', teamAssigned: '0', status: 'Unassigned' },
+    { id: 10, client: 'Nick Fury', section: 'JDF', organization: 'Mock Org name', teamAssigned: '0', status: 'Completed' },
+    { id: 11, client: 'Peter Parker', section: 'JDF', organization: 'Mock Org name', teamAssigned: '0', status: 'Completed' }
 ];
 const createNewRow = (prevRows: {
     id: number;
-    teamAssigned: number;
+    teamAssigned: string;
     section: string;
     organization: string;
     client: string;
     status: string;
-}[], teamAssigned: number,
+}[], teamAssigned: string,
     section: string,
     organization: string,
     client: string, 
@@ -132,13 +133,32 @@ const createNewRow = (prevRows: {
 export default function ProjectsGrid() {
     const [selectionModel, setSelectionModel] = React.useState<GridRowId[]>([]);
     const [rows, setRows] = React.useState(() => projectsRows);
+    const [selectedProject, setSelectedProject] = React.useState([{
+        teamAssigned: '',
+        section: '',
+        organization: '',
+        client: '',
+        status: ''
+    }]);
+    const [manageDisabled, setManageDisabled] = React.useState(true);
+
+    function checkDisableManage() {
+        if (selectedProject == null
+            || selectedProject.length == 0
+            || selectedProject.length > 1
+            || selectedProject[0].client == '') {
+            setManageDisabled(true)
+        } else {
+            setManageDisabled(false)
+        }
+    }
 
     const deleteProjects = () => {
         setRows((rows) => rows.filter((r) => !selectionModel.includes(r.id)));
     };
 
     const getCreateProjectInfo = (
-        teamAssigned: number, 
+        teamAssigned: string, 
         section: string, 
         organization: string, 
         client: string,
@@ -148,6 +168,11 @@ export default function ProjectsGrid() {
         setRows((prevRows) => [...prevRows, createNewRow(prevRows, teamAssigned, section, organization, client, status)]);
 
     }
+
+    React.useEffect(() => {
+        checkDisableManage();
+    })
+
     return (
         <div className="main_content">
             <div className="top_buttons">
@@ -184,7 +209,10 @@ export default function ProjectsGrid() {
                         border: 2
                     }}
                     selectionModel={selectionModel}
-                    onSelectionModelChange={setSelectionModel}
+                    onSelectionModelChange={(newSelectionModel) => {
+                        setSelectionModel(newSelectionModel);
+                        setSelectedProject(rows.filter((r: any) => newSelectionModel.includes(r.id)));
+                    }}
                     getRowClassName={(params) =>
                         params.indexRelativeToCurrentPage % 2 === 0 ? 'even' : 'odd'
                     }
@@ -211,13 +239,7 @@ export default function ProjectsGrid() {
                 </div>
 
                 <div className="bottom_buttons_group">
-                    <Button variant="contained" onClick={() => {
-                        // TODO: Handle click here
-                        console.log('Manage project clicked')
-                    }}
-                    >
-                        Manage Selected Project
-                    </Button>
+                    <ManageProjectModal rows={rows} selectionModel={selectionModel} manageDisabled={manageDisabled} />
                     <RemoveProjectsModal deleteProjects={deleteProjects}/>
                 </div>
             </div>

--- a/react-app/src/components/TeamGrid/index.tsx
+++ b/react-app/src/components/TeamGrid/index.tsx
@@ -173,7 +173,6 @@ export default function TeamGrid() {
         
         console.log("creating a new team")
         setRows((prevRows) => [...prevRows, createNewRow(prevRows, teamNumber, section, project, client, professor)]);
-
     } 
 
     React.useEffect(() => {

--- a/react-app/src/components/TeamGrid/index.tsx
+++ b/react-app/src/components/TeamGrid/index.tsx
@@ -5,6 +5,7 @@ import { alpha, styled } from '@mui/material/styles';
 import { grey } from '@mui/material/colors';
 import CreateTeamModal from '../CreateTeamModal/createTeamModal';
 import RemoveTeamModal from '../RemoveTeamModal/RemoveTeamModal';
+import ManageTeamModal from '../ManageTeamModal/manageTeamModal'
 
 import './TeamGrid.css';
 
@@ -218,13 +219,7 @@ export default function TeamGrid() {
                 </div>
 
                 <div className="bottom_buttons_group">
-                    <Button variant="contained" onClick={() => {
-                        // TODO: Handle click here
-                        console.log('manage team clicked')
-                    }}
-                    >
-                        Manage Selected Team
-                    </Button>
+                    <ManageTeamModal />
                     <RemoveTeamModal deleteTeams={deleteTeams}/>
                 </div>
             </div>

--- a/react-app/src/components/TeamGrid/index.tsx
+++ b/react-app/src/components/TeamGrid/index.tsx
@@ -139,6 +139,7 @@ const createNewRow = (prevRows: {
 export default function TeamGrid() {
     const [rows, setRows] = React.useState(() => rowsmock);
     const [selectionModel, setSelectionModel] = React.useState<GridRowId[]>([]);
+    
 
     const deleteTeams = () => {
         setRows((rows) => rows.filter((r) => !selectionModel.includes(r.id)));
@@ -154,7 +155,7 @@ export default function TeamGrid() {
         console.log("creating a new team")
         setRows((prevRows) => [...prevRows, createNewRow(prevRows, teamNumber, section, project, client, professor)]);
 
-    }
+    } 
 
     return (
         <div className="main_content">
@@ -219,7 +220,7 @@ export default function TeamGrid() {
                 </div>
 
                 <div className="bottom_buttons_group">
-                    <ManageTeamModal />
+                    <ManageTeamModal rows={rows} selectionModel={selectionModel}/>
                     <RemoveTeamModal deleteTeams={deleteTeams}/>
                 </div>
             </div>

--- a/react-app/src/components/TeamGrid/index.tsx
+++ b/react-app/src/components/TeamGrid/index.tsx
@@ -139,11 +139,30 @@ const createNewRow = (prevRows: {
 export default function TeamGrid() {
     const [rows, setRows] = React.useState(() => rowsmock);
     const [selectionModel, setSelectionModel] = React.useState<GridRowId[]>([]);
+    const [selectedTeam, setSelectedTeam] = React.useState([{
+        teamNumber: '',
+        section: '',
+        project: '',
+        client: '',
+        professor: ''
+    }]);
+    const [manageDisabled, setManageDisabled] = React.useState(true)
     
 
     const deleteTeams = () => {
         setRows((rows) => rows.filter((r) => !selectionModel.includes(r.id)));
     };
+
+    function checkDisableManage() {
+        if (selectedTeam == null 
+            || selectedTeam.length == 0
+            || selectedTeam.length > 1
+            || selectedTeam[0].teamNumber == '') {
+            setManageDisabled(true)
+        } else {
+            setManageDisabled(false)
+        }
+    }
 
     const getCreateTeamInfo = (
         teamNumber: string, 
@@ -156,6 +175,11 @@ export default function TeamGrid() {
         setRows((prevRows) => [...prevRows, createNewRow(prevRows, teamNumber, section, project, client, professor)]);
 
     } 
+
+    React.useEffect(() => {
+        checkDisableManage();
+    })
+
 
     return (
         <div className="main_content">
@@ -192,7 +216,10 @@ export default function TeamGrid() {
                     border: 2
                 }}
                 selectionModel={selectionModel}
-                onSelectionModelChange={setSelectionModel}
+                onSelectionModelChange={(newSelectionModel) => {
+                    setSelectionModel(newSelectionModel);
+                    setSelectedTeam(rows.filter((r: any) => newSelectionModel.includes(r.id)));
+                }}
                 getRowClassName={(params) =>
                     params.indexRelativeToCurrentPage % 2 === 0 ? 'even' : 'odd'
                 }
@@ -220,7 +247,7 @@ export default function TeamGrid() {
                 </div>
 
                 <div className="bottom_buttons_group">
-                    <ManageTeamModal rows={rows} selectionModel={selectionModel}/>
+                    <ManageTeamModal rows={rows} selectionModel={selectionModel} manageDisabled={manageDisabled} />
                     <RemoveTeamModal deleteTeams={deleteTeams}/>
                 </div>
             </div>


### PR DESCRIPTION
When a client selects ONE client/project/team, the manage button becomes activated. The manage button is disabled if nothing is selected or more than one row is selected. 

When manage client/project/team is clicked, a popup is opened. The code is ready for the next tickets which will be displaying all of the information for that client/project/team on this page and allowing the user to edit it.