### PR TITLE
Display all info on manage team page

### DIFF
--- a/react-app/src/components/ManageTeamModal/manageTeamModal.tsx
+++ b/react-app/src/components/ManageTeamModal/manageTeamModal.tsx
@@ -59,7 +59,12 @@ export default function ManageTeamModal(props: {
                         Team {selectedTeam[0].teamNumber}
                     </Typography>
                     <Typography component={'div'} id="modal-modal-description" sx={{ mt: 2 }}>
-                        {/* Team info will go here */}                        
+                        <b>Section: </b>  {selectedTeam[0].section} <br/>
+                        <b>Project: </b>  {selectedTeam[0].project} <br />
+                        <b>Client: </b>  {selectedTeam[0].client} <br />
+                        <b>Professor: </b>  {selectedTeam[0].professor} <br />
+                        <b>Students: </b> 
+
                     </Typography>
 
                 </Box>


### PR DESCRIPTION
Displays all the information for the selected row on the manage team modal. Does not display the registered students yet because we aren't displaying those in the grid. Will those be pulled from the backend? I think it makes the most sense for the frontend to fetch the student names and emails that go with the team from the backend here, instead of having the frontend store them all and broadcast them to the child component when the modal is opened. Leaving that out for now - we can reassess this in our next meeting/next sprint. 