### PR TITLE
Error checking client creation

### DIFF
--- a/react-app/src/components/CreateClientModal/createClientModal.tsx
+++ b/react-app/src/components/CreateClientModal/createClientModal.tsx
@@ -37,10 +37,22 @@ export default function CreateClientModal( {getCreateClientInfo}: any) {
 
 
     const handleOpen = () => setOpen(true);
-    const handleClose = () => setOpen(false);
+    const handleClose = () => {
+        setFirstName('')
+        setLastName('')
+        setOrganization('')
+        setEmail('')
+        setClientStatus('')
+        setOpen(false);
+    }
 
     const handleCreateClick = () => {
         getCreateClientInfo(firstName, lastName, organization, email, clientStatus);
+        setFirstName('')
+        setLastName('')
+        setOrganization('')
+        setEmail('')
+        setClientStatus('')
         handleClose();
     }
 
@@ -119,9 +131,9 @@ export default function CreateClientModal( {getCreateClientInfo}: any) {
                             id="standard-start-adornment"
                             sx={{ m: 1, width: '25ch' }}
                             margin="normal"
+                            onChange={handleFirstNameChange}
                             error={firstName == ''}
                             helperText={genericHelperText(firstName)}
-                            onChange={handleFirstNameChange}
                         />
 
                         <TextField
@@ -129,9 +141,9 @@ export default function CreateClientModal( {getCreateClientInfo}: any) {
                             id="standard-start-adornment"
                             sx={{ m: 1, width: '25ch' }}
                             margin="normal"
+                            onChange={handleLastNameChange}
                             error={lastName == ''}
                             helperText={genericHelperText(lastName)}
-                            onChange={handleLastNameChange}
                         />
 
                         <TextField
@@ -139,9 +151,9 @@ export default function CreateClientModal( {getCreateClientInfo}: any) {
                             id="standard-start-adornment"
                             sx={{ m: 1, width: '25ch' }}
                             margin="normal"
+                            onChange={handleOrganizationChange}
                             error={organization == ''}
                             helperText={genericHelperText(organization)}
-                            onChange={handleOrganizationChange}
                         />
 
                         <TextField
@@ -149,14 +161,14 @@ export default function CreateClientModal( {getCreateClientInfo}: any) {
                             id="standard-start-adornment"
                             sx={{ m: 1, width: '25ch' }}
                             margin="normal"
-                            error={email == '' 
-                            || !(email.includes('@') 
-                                        && (email.includes('.com') 
-                                        || email.includes('.edu') 
-                                        || email.includes('.net') 
+                            onChange={handleEmailChange}
+                            error={email == ''
+                                || !(email.includes('@')
+                                    && (email.includes('.com')
+                                        || email.includes('.edu')
+                                        || email.includes('.net')
                                         || email.includes('.org')))}
                             helperText={emailHelperText()}
-                            onChange={handleEmailChange}
                         />
                     <FormControl>
                         <InputLabel id="select-label">Client Status</InputLabel>

--- a/react-app/src/components/CreateClientModal/createClientModal.tsx
+++ b/react-app/src/components/CreateClientModal/createClientModal.tsx
@@ -11,6 +11,7 @@ import MenuItem from '@mui/material/MenuItem';
 
 
 import Modal from '@mui/material/Modal';
+import { FormHelperText } from '@mui/material';
 
 const style = {
     position: 'absolute' as 'absolute',
@@ -31,6 +32,8 @@ export default function CreateClientModal( {getCreateClientInfo}: any) {
     const [lastName, setLastName] = React.useState('');
     const [organization, setOrganization] = React.useState('');
     const [email, setEmail] = React.useState('');
+    const [disabled, setDisabled] = React.useState(true);
+
 
 
     const handleOpen = () => setOpen(true);
@@ -60,6 +63,39 @@ export default function CreateClientModal( {getCreateClientInfo}: any) {
     const handleClientStatusChange = (event: SelectChangeEvent) => {
         setClientStatus(event.target.value);
     }
+
+    React.useEffect(() => {
+        formValidation()
+    });
+
+    function formValidation() {
+        if (firstName != '' 
+            && lastName != ''
+            && organization != ''
+            && email != '')
+            setDisabled(false)
+        else
+            setDisabled(true)
+    }
+
+    function genericHelperText(input: any) {
+        if (input == '')
+            return 'This field cannot be empty'
+        else
+            return ''
+    }
+
+    function emailHelperText() {
+        if (email == '') {
+            return 'This field cannot be empty'
+        } else if (!(email.includes('@') && (email.includes('.com') || email.includes('.edu')
+            || email.includes('.net')
+            || email.includes('.org')))) {
+                return 'Please enter a valid email (ex. burdell5@gatech.edu)'
+        } else {
+            return ''
+        }
+    }
     
     return (
         <div>
@@ -83,6 +119,8 @@ export default function CreateClientModal( {getCreateClientInfo}: any) {
                             id="standard-start-adornment"
                             sx={{ m: 1, width: '25ch' }}
                             margin="normal"
+                            error={firstName == ''}
+                            helperText={genericHelperText(firstName)}
                             onChange={handleFirstNameChange}
                         />
 
@@ -91,6 +129,8 @@ export default function CreateClientModal( {getCreateClientInfo}: any) {
                             id="standard-start-adornment"
                             sx={{ m: 1, width: '25ch' }}
                             margin="normal"
+                            error={lastName == ''}
+                            helperText={genericHelperText(lastName)}
                             onChange={handleLastNameChange}
                         />
 
@@ -99,6 +139,8 @@ export default function CreateClientModal( {getCreateClientInfo}: any) {
                             id="standard-start-adornment"
                             sx={{ m: 1, width: '25ch' }}
                             margin="normal"
+                            error={organization == ''}
+                            helperText={genericHelperText(organization)}
                             onChange={handleOrganizationChange}
                         />
 
@@ -107,9 +149,17 @@ export default function CreateClientModal( {getCreateClientInfo}: any) {
                             id="standard-start-adornment"
                             sx={{ m: 1, width: '25ch' }}
                             margin="normal"
+                            error={email == '' 
+                            || !(email.includes('@') 
+                                        && (email.includes('.com') 
+                                        || email.includes('.edu') 
+                                        || email.includes('.net') 
+                                        || email.includes('.org')))}
+                            helperText={emailHelperText()}
                             onChange={handleEmailChange}
                         />
-
+                    <FormControl>
+                        <InputLabel id="select-label">Client Status</InputLabel>
                         <Select
                             labelId="demo-simple-select-standard-label"
                             id="demo-simple-select-standard"
@@ -121,8 +171,10 @@ export default function CreateClientModal( {getCreateClientInfo}: any) {
                             <MenuItem value="Prospective">Prospective</MenuItem>
                             <MenuItem value="Inactive">Inactive</MenuItem>
                         </Select>
+                    </FormControl>
+                        
                     </Typography>
-                    <Button variant="contained" onClick={() => { handleCreateClick() }}>
+                    <Button variant="contained" disabled={disabled} onClick={() => { handleCreateClick() }}>
                         Create Client
                     </Button>
 


### PR DESCRIPTION
Added error checking/submit button disable on client creation page. Unsure what is best - display that all fields need to not be empty as an error when you open the modal, just disable the submit button until all fields have something entered/their individual requirements met, or something else? Unsure if it is overwhelming that every field is erroring right when you open the modal, or if it is a good thing because it would be too ambiguous to have the submit button disabled without actually telling the user why. 